### PR TITLE
Enabled register button on apps management if app is non-atlantis and all the required values are filled

### DIFF
--- a/public/ngapp/register/controllers.js
+++ b/public/ngapp/register/controllers.js
@@ -454,7 +454,7 @@ controllers.controller('AppsCtrl', ['$scope', '$rootScope', '$state', 'appsInfoF
  'deleteModal', 'addModal', '$timeout', 'updateApp',
   function ($scope, $rootScope, $state, appsInfoFactory, deleteModal, addModal, $timeout, updateApp) {
 
-    $scope.apps = {};
+    $scope.apps = [];
     $scope.name = "";
     $scope.root = "";
     $scope.repo = "";
@@ -584,5 +584,15 @@ controllers.controller('AppsCtrl', ['$scope', '$rootScope', '$state', 'appsInfoF
         $scope.non_atlantis = false;
         console.log(result);
       });
+    };
+
+    $scope.setValidityForNonAtlantis = function (non_atlantis) {
+      if (non_atlantis) {
+        $scope.appInfoForm.repo.$setValidity('required', true);
+        $scope.appInfoForm.root.$setValidity('required', true);
+      } else {
+        $scope.appInfoForm.repo.$setValidity('required', false);
+        $scope.appInfoForm.root.$setValidity('required', false);
+      }
     };
   }]);

--- a/public/ngapp/register/templates/apps.html
+++ b/public/ngapp/register/templates/apps.html
@@ -20,7 +20,7 @@
           Non Atlantis
         </div>
         <div class="col-md-1">
-          <switch id="enabled" name="enabled" ng-model="non_atlantis" on="Yes" off="No" class="green"></switch>
+          <switch id="enabled" name="enabled" ng-model="non_atlantis" on="Yes" off="No" class="green" ng-change="setValidityForNonAtlantis(non_atlantis)"></switch>
         </div>
         <div class="col-md-2">
           <input type="text" name="appName" class="form-control" ng-model="name" placeholder="Name..." required></input>


### PR DESCRIPTION
- Changed the type of $scope.apps from json to array to push new values in it.
- To register the new app of type non-atlantis, enabled the register button if all the required values are filled.
